### PR TITLE
Fixing a broken link to the hackkc page from _includes/header.html

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -55,7 +55,7 @@
                             and help us #HackforChange
                         </p>
                     </div>
-                    <a class="btn btn-success btn-lg" href="{{ site.baseurl }}/hackkc.html">Learn More</a>
+                    <a class="btn btn-success btn-lg" href="{{ site.baseurl }}/hackkc">Learn More</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
I noticed that the link to the HackKC page from the Learn More button in the carousel of the header was broken, so I thought that would be a good opportunity to get a fork of this site going and play around with it. The Jetkit preview of the site at https://jekit.codeforamerica.org/rockhold/codeforkansascity.github.io/master/ doesn't seem to like the way the links are specified for navigating to the HackKC page, but it does work when I serve it up locally. Since this same issue occurs when using Jetkit for the nav bar link to the HackKC page (but works on the live site), I thought I'd go ahead and submit this.
